### PR TITLE
Fix a malformed query in advanced search

### DIFF
--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -369,11 +369,11 @@ class ExtensionsController < ApplicationController
     end
 
     if params[:archs]
-      scope = scope.for_architectures(Array.wrap(params[:archs]))
+      scope = scope.where(id: Extension.for_architectures(Array.wrap(params[:archs])))
     end
 
     if params[:platforms]
-      scope = scope.for_platforms(Array.wrap(params[:platforms]))
+      scope = scope.where(id: Extension.for_platforms(Array.wrap(params[:platforms])))
     end
 
     return scope


### PR DESCRIPTION
<blockquote class="trello-card"><a href="https://trello.com/c/CsVeGgy0/165-search-error">Search Error</a></blockquote>