### PR TITLE
Move unique name validation to owner_name scope on extensions

### DIFF
--- a/app/interactors/set_up_hosted_extension.rb
+++ b/app/interactors/set_up_hosted_extension.rb
@@ -10,10 +10,6 @@ class SetUpHostedExtension
   delegate :version_name, to: :context
 
   def call
-    extension.update_attributes(
-      owner_name: ENV['HOST_ORGANIZATION']
-    )
-
     extension_version = extension.extension_versions.create!(version: version_name)
 
     if extension.tmp_source_file.attached?
@@ -31,4 +27,5 @@ class SetUpHostedExtension
       end
     end
   end
+
 end

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -129,8 +129,7 @@ class Extension < ApplicationRecord
 
   # Validations
   # --------------------
-  validates :name, presence: true, uniqueness: { case_sensitive: false }, format: /\A[\w\s_-]+\z/i
-  validates :lowercase_name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { scope: :owner_name, case_sensitive: false, message: "already exists in this namespace" }, format: /\A[\w\s_-]+\z/i
   # validates :extension_versions, presence: true
   validates :source_url, url: {
     allow_blank: true,

--- a/app/services/create_extension.rb
+++ b/app/services/create_extension.rb
@@ -11,7 +11,9 @@ class CreateExtension
     candidate = Extension.new(@params) do |extension|
       if extension.hosted?
         extension.owner = User.host_organization
+        extension.owner_name = ENV['HOST_ORGANIZATION']
       else
+        extension.github_organization, extension.owner_name = SetUpGithubExtension.gather_github_info(extension, @octokit, @user)
         extension.owner = @user
       end
     end

--- a/db/migrate/20190405182158_update_uniquness_constraint_on_extensions.rb
+++ b/db/migrate/20190405182158_update_uniquness_constraint_on_extensions.rb
@@ -1,0 +1,11 @@
+class UpdateUniqunessConstraintOnExtensions < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :extensions, name: "index_extensions_on_lowercase_name"
+    add_index :extensions, [:owner_name, :lowercase_name], name: "index_extensions_on_owner_name_and_lowercase_name", unique: true
+  end
+
+  def down
+    remove_index :extensions, name: "index_extensions_on_owner_name_and_lowercase_name"
+    add_index :extensions, :lowercase_name, name: "index_extensions_on_lowercase_name", unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_26_050254) do
+ActiveRecord::Schema.define(version: 2019_04_05_182158) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -337,8 +336,8 @@ ActiveRecord::Schema.define(version: 2019_01_26_050254) do
     t.bigint "tier_id"
     t.index ["enabled"], name: "index_extensions_on_enabled"
     t.index ["github_organization_id"], name: "index_extensions_on_github_organization_id"
-    t.index ["lowercase_name"], name: "index_extensions_on_lowercase_name", unique: true
     t.index ["name"], name: "index_extensions_on_name"
+    t.index ["owner_name", "lowercase_name"], name: "index_extensions_on_owner_name_and_lowercase_name", unique: true
     t.index ["owner_name"], name: "index_extensions_on_owner_name"
     t.index ["tier_id"], name: "index_extensions_on_tier_id"
     t.index ["user_id"], name: "index_extensions_on_user_id"

--- a/spec/interactors/set_up_github_extension_spec.rb
+++ b/spec/interactors/set_up_github_extension_spec.rb
@@ -24,11 +24,6 @@ describe SetUpGithubExtension do
   end
 
   describe '.call' do
-    it "sets the extension's repo info" do
-      expect(context).to be_a_success
-      expect(extension.github_organization.name).to eql 'my-org'
-      expect(extension.owner_name              ).to eql 'my-org'
-    end
 
     it "kicks off a worker to gather metadata about the valid extension" do
       expect(CollectExtensionMetadataWorker).to receive(:perform_async)

--- a/spec/interactors/set_up_hosted_extension_spec.rb
+++ b/spec/interactors/set_up_hosted_extension_spec.rb
@@ -22,13 +22,6 @@ describe SetUpHostedExtension do
   end
 
   describe '.call' do
-    it "sets the extension's owner name" do
-      orig_owner_name = extension.owner_name
-      subject
-      extension.reload
-      expect(extension.owner_name).to     be_present
-      expect(extension.owner_name).to_not eql orig_owner_name
-    end
 
     it "transfers the source file attachment to the new version child" do
       expect(extension.tmp_source_file).to     be_attached

--- a/spec/services/create_extension_spec.rb
+++ b/spec/services/create_extension_spec.rb
@@ -23,8 +23,8 @@ describe CreateExtension do
     'github_url'     => "https://github.com/#{github_url}",
     'lowercase_name' => "test",
   } }
-  let(:expected_unnormalized_attributes) { Extension.new(params.merge(owner: user)).attributes }
-  let(:expected_normalized_attributes)   { Extension.new(params.merge(owner: user)).attributes.merge(normalized_attributes) }
+  let(:expected_unnormalized_attributes) { Extension.new(params.merge(owner: user, owner_name: 'some_user')).attributes }
+  let(:expected_normalized_attributes)   { Extension.new(params.merge(owner: user, owner_name: 'some_user')).attributes.merge(normalized_attributes) }
   let(:top_level_contents)               { [{name: 'bonsai.yml'}] }
 
   before do
@@ -114,7 +114,7 @@ describe CreateExtension do
     let(:extension)      { build :extension, owner: user }
 
     subject { CreateExtension.new(params, user) }
-   
+
     it "creates a new User for Hosted Extensions" do
       new_extension = subject.process!
       expect(User.find_by(company: ENV['HOST_ORGANIZATION'])).to be_present


### PR DESCRIPTION
- Removed unique database index for "lowercase_name" on "extensions" table.
- Added multi-column unique database index for "owner_name" and "lowercase_name" on the extensions table.
- Removed rails validation on :lowercase_name in the Extension model.  This validation was functionally the equivalent of the existing validation on the :name field.
- Added scope: :owner_name to the uniqueness validation on the Extension name field.  This ensures that the namespace / extension name combination are unique.
- Refactored CreateExtension service, SetUpGithubExtension interactor, and SetUpHostedExtension interactor to set owner_name on an extension prior to the extension being saved.  This allows us to run validations on the owner_name field.
- Updated specs to reflect refactors to CreateExtension service, SetUpGithubExtension interactor, and SetUpHostedExtension interactor.